### PR TITLE
Added fully-qualified path name for base path so that tests would pass

### DIFF
--- a/t/reportpassedlib/TestsFor/FailChild.pm
+++ b/t/reportpassedlib/TestsFor/FailChild.pm
@@ -1,5 +1,5 @@
 package TestsFor::FailChild;
-use Test::Class::Moose extends => 'Fail';
+use Test::Class::Moose extends => 'TestsFor::Fail';
 
 sub test_a_good {
     ok 1;
@@ -20,3 +20,4 @@ sub test_b_bad {
 sub test_another { ok 1 }
 
 1;
+


### PR DESCRIPTION
Extends clause wasn't using full-qualified path name. Test was failing on my installation and I couldn't upgrade. This should fix it.