### PR TITLE
Fix homepage links in docs to reflect current location

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ version 0.58
 
 # DESCRIPTION
 
-See the [Test::Class::Moose home page](http://ovid.github.io/test-class-moose/) for
+See the [Test::Class::Moose home page](http://test-class-moose.github.io/test-class-moose/) for
 a summary.
 
 `Test::Class::Moose` is a powerful testing framework for Perl. Out of the box

--- a/lib/Test/Class/Moose.pm
+++ b/lib/Test/Class/Moose.pm
@@ -260,7 +260,7 @@ __END__
 
 =head1 DESCRIPTION
 
-See the L<Test::Class::Moose home page|http://ovid.github.io/test-class-moose/> for
+See the L<Test::Class::Moose home page|http://test-class-moose.github.io/test-class-moose/> for
 a summary.
 
 C<Test::Class::Moose> is a powerful testing framework for Perl. Out of the box


### PR DESCRIPTION
Current homepage links in docs 404 in a couple spots, presumably linking to a previous location.