### PR TITLE
Allow _constructor_parameter_sets to return an empty list

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl distribution Test-Class-Moose
 
 {{$NEXT}}
+        * Allow _constructor_parameter_sets to return an empty list (GitHub issue #47)
 
 0.58 2014-09-05
         * Add a passed() method to class and method report objects (GitHub issue #30)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ does not start with `test_`:
         ...
     }
 
-__Note__: Prior to version 0.51, this feature only worked if you had the
+**Note**: Prior to version 0.51, this feature only worked if you had the
 optional `Sub::Attribute` installed.
 
 ## Plans
@@ -169,7 +169,7 @@ Do not run tests in test control methods. This will cause the test control
 method to fail (this is a feature, not a bug).  If a test control method
 fails, the class/method will fail and testing for that class should stop.
 
-__Every__ test control method will be called as a method. The invocant is the
+**Every** test control method will be called as a method. The invocant is the
 instance of your test class
 
 The available test control methods are:
@@ -247,7 +247,7 @@ To override a test control method, just remember that this is OO:
 
 # TEST CLASS INSTANCES
 
-__This feature is still considered experimental.__
+**This feature is still considered experimental.**
 
 By default, each test class you create will be instantiated once. However, you
 can tell the [Test::Class::Moose::Runner](https://metacpan.org/pod/Test::Class::Moose::Runner) to create multiple instances of a
@@ -282,7 +282,9 @@ class's constructor. Here's a really dumb example:
     sub test_something { ... }
 
 The test runner will run all the test methods in your class _once per
-instance_, and each instance will be run in its own subtest.
+instance_, and each instance will be run in its own subtest. You can
+dynamically decide to skip your test class completely by having
+`_constructor_parameter_sets` return an empty list.
 
 Note that this feature has great potential for abuse, so use it
 cautiously. That said, there are cases where this feature can greatly simplify
@@ -309,6 +311,10 @@ If you wish to skip a class, set the reason in the `test_startup` method.
         my $test = shift;
         $test->test_skip("I don't want to run this class");
     }
+
+If you are using [test class instances](#test-class-instances), you
+can also make `_constructor_parameter_sets` return an empty list,
+which will result in the class being skipped.
 
 If you wish to skip an individual method, do so in the `test_setup` method.
 

--- a/lib/Test/Class/Moose.pm
+++ b/lib/Test/Class/Moose.pm
@@ -522,7 +522,9 @@ class's constructor. Here's a really dumb example:
  sub test_something { ... }
 
 The test runner will run all the test methods in your class I<once per
-instance>, and each instance will be run in its own subtest.
+instance>, and each instance will be run in its own subtest. You can
+dynamically decide to skip your test class completely by having
+C<_constructor_parameter_sets> return an empty list.
 
 Note that this feature has great potential for abuse, so use it
 cautiously. That said, there are cases where this feature can greatly simplify
@@ -549,6 +551,10 @@ If you wish to skip a class, set the reason in the C<test_startup> method.
         my $test = shift;
         $test->test_skip("I don't want to run this class");
     }
+
+If you are using L<test class instances|/"TEST CLASS INSTANCES">, you
+can also make C<_constructor_parameter_sets> return an empty list,
+which will result in the class being skipped.
 
 If you wish to skip an individual method, do so in the C<test_setup> method.
 

--- a/lib/Test/Class/Moose/Role/Executor.pm
+++ b/lib/Test/Class/Moose/Role/Executor.pm
@@ -53,6 +53,12 @@ sub _tcm_run_test_class {
             = $test_class->_tcm_make_test_class_instances(
             $self->test_configuration->args );
 
+        unless (%test_instances) {
+            my $message = "Skipping '$test_class': no test instances found";
+            $self->test_configuration->builder->plan(skip_all => $message);
+            return;
+        }
+
         foreach my $test_instance_name (sort keys %test_instances) {
             my $test_instance = $test_instances{$test_instance_name};
 

--- a/t/parameterizedlib/TestsFor/Empty.pm
+++ b/t/parameterizedlib/TestsFor/Empty.pm
@@ -1,0 +1,16 @@
+package TestsFor::Empty;
+use Test::Class::Moose;
+with 'Test::Class::Moose::Role::ParameterizedInstances';
+
+sub _constructor_parameter_sets {
+    # dynamically decided that there is nothing to do (e.g., because
+    # I'm being called in the context of an abstract base class)
+    return ();
+}
+
+sub test_one_set {
+    my $self = shift;
+    fail('this test should never be called');
+}
+
+1;


### PR DESCRIPTION
The proposed patch allows `_constructor_parameter_sets` to return an empty list, thereby skipping the creation of test class instances.

For some background, this is why I think this is useful:
After some discussion on #moose, we changed our test infrastructure to have one base class (which inherits from T:C:M) and have several subclasses, one for each data path that exists in our application. For each subclass, there is a number of input-output combinations (files that are part of the testsuite), and for each of these combinations one test class instance should be created, and all tests performed.
Without this patch, T:C:M will call `_constructor_parameter_sets` on each T:C:M class, even it it's an abstract class which has no test files associated with it, and the code is forced to create at least one dummy instance (thereby supplying all required attributes, etc), just so that it can later call `skip_test`.