### PR TITLE
Fix test failure in TestsFor::FailChild

### DIFF
--- a/t/reportpassedlib/TestsFor/FailChild.pm
+++ b/t/reportpassedlib/TestsFor/FailChild.pm
@@ -1,5 +1,5 @@
 package TestsFor::FailChild;
-use Test::Class::Moose extends => 'Fail';
+use Test::Class::Moose extends => 'TestsFor::Fail';
 
 sub test_a_good {
     ok 1;


### PR DESCRIPTION
Hi,
I'm seeing

t/reportpassed.t .......... Can't locate Fail.pm in @INC (you may need to install the Fail module) (@INC contains: t/reportpassedlib . /home/jonathan/devel/test-class-moose/blib/lib /home/jonathan/devel/test-class-moose/blib/arch /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at t/reportpassedlib/TestsFor/FailChild.pm line 2.
BEGIN failed--compilation aborted at t/reportpassedlib/TestsFor/FailChild.pm line 2.
Compilation failed in require at (eval 300) line 1.
BEGIN failed--compilation aborted at (eval 300) line 1.
BEGIN failed--compilation aborted at t/reportpassed.t line 5.
t/reportpassed.t .......... Dubious, test returned 2 (wstat 512, 0x200)

The attached would seem to fix that.
