### PR TITLE
Test::Class::Moose::Role should import strict and warnings

### DIFF
--- a/lib/Test/Class/Moose/Role.pm
+++ b/lib/Test/Class/Moose/Role.pm
@@ -27,6 +27,8 @@ END
 
     eval $preamble;
     croak($@) if $@;
+    strict->import;
+    warnings->import;
     no strict "refs";
     *{"$caller\::Tags"}  = \&Tags;
     *{"$caller\::Test"}  = \&Test;


### PR DESCRIPTION
Test::Class::Moose::Role currently does not import strict and warnings into the caller.