### PR TITLE
TCM::Config use()'s Test::Builder

### DIFF
--- a/lib/Test/Class/Moose/Config.pm
+++ b/lib/Test/Class/Moose/Config.pm
@@ -6,6 +6,7 @@ use 5.10.0;
 use Moose;
 use Moose::Util::TypeConstraints;
 use TAP::Formatter::Color;
+use Test::Builder;
 use namespace::autoclean;
 
 subtype 'ArrayRefOfStrings', as 'Maybe[ArrayRef[Str]]';


### PR DESCRIPTION
If nothing else loads Test::Builder, you can get:

```
Can't locate object method "new" via package "Test::Builder" (perhaps you forgot to load "Test::Builder"?) at /opt/perl5.20.2/lib/site_perl/5.20.2/Test/Class/Moose/Config.pm line 31.
```