### PR TITLE
Implement "use Test::Class::Moose bare => 1"

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for Perl distribution Test-Class-Moose
 
 {{$NEXT}}
+        * If you "use Test::Class::Moose bare => 1" you will no longer get
+          Test::Most exported into your class. Instead, you can load the
+          testing module(s) of your choice.
 
 0.67     2015-11-30
         * Same as 0.66, but repeating changes from 0.63 since there's a bunch

--- a/dist.ini
+++ b/dist.ini
@@ -46,6 +46,7 @@ stopwords = strawman
 stopwords = subtest
 stopwords = subtests
 stopwords = teardown
+stopwords = toolkits
 stopwords = un
 stopwords = xUnit
 ; annocpan.org was not responding

--- a/t/bare.t
+++ b/t/bare.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Warnings qw( warnings );
+
+my $package = <<'EOF';
+package TestFor::Bare;
+
+use Test::Class::Moose bare => 1;
+use Test::More;
+use List::SomeUtils qw( any );
+EOF
+
+is_deeply(
+    [ warnings { eval $package } ],
+    [],
+    'no warnings from using Test::Class::Moose with List::SomeUtils'
+);
+
+done_testing();


### PR DESCRIPTION
This prevents TCM from exporting Test::Most into the calling class.