### PR TITLE
Explicitly detect classes which are not TCM classes and give a useful error

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,15 @@ Revision history for Perl distribution Test-Class-Moose
 
 {{$NEXT}}
 
+  [ENHANCEMENTS]
+
+  * If you pass one or more test class names to the Runner class explicitly
+    and those classes are either not loaded or not subclasses of
+    Test::Class::Moose, you'll get a better error message. Previously this
+    would die with an unhelpful error about missing methods. Reported by Andy
+    Cunningham with additional clarification from hoppfrosch. GH #57.
+
+
 0.80     2016-09-25
 
   [BUG FIXES]

--- a/lib/Test/Class/Moose/Role/Executor.pm
+++ b/lib/Test/Class/Moose/Role/Executor.pm
@@ -42,6 +42,20 @@ sub runtests {
     $report->_start_benchmark;
     my @test_classes = $self->test_classes;
 
+    my @bad = grep { !$_->isa('Test::Class::Moose') } @test_classes;
+    if (@bad) {
+        my $msg = 'Found the following class';
+        $msg .= 'es' if @bad > 1;
+        $msg
+          .= ' that '
+          . ( @bad > 1 ? 'are'        : 'is' ) . ' not '
+          . ( @bad > 1 ? 'subclasses' : 'a subclass' )
+          . " of Test::Class::Moose: @bad";
+        $msg .= ' (did you load '
+          . ( @bad > 1 ? 'these classes' : 'this class' ) . '?)';
+        die $msg;
+    }
+
     context_do {
         my $ctx = shift;
 

--- a/t/bare.t
+++ b/t/bare.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More;
-use Test::Warnings qw( warnings );
+use Test2::Bundle::Extended;
+use Test::Warnings qw( warnings :no_end_test );
 
 my $package = <<'EOF';
 package TestFor::Bare;
@@ -12,9 +12,9 @@ use Test::More;
 use List::SomeUtils qw( any );
 EOF
 
-is_deeply(
+is(
     [ warnings { eval $package } ],
-    [],
+    array { end(); },
     'no warnings from using Test::Class::Moose with List::SomeUtils'
 );
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -3,8 +3,7 @@
 use lib 'lib', 't/lib';
 
 use Test2::API qw( intercept );
-use Test2::Tools::Basic qw( done_testing );
-use Test2::Tools::Compare qw( array call end event F is match object T );
+use Test2::Bundle::Extended;
 use Test2::Tools::Subtest qw( subtest_streamed );
 use Test::Events;
 use Test::Reporting qw( test_report );

--- a/t/environment.t
+++ b/t/environment.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 use lib 'lib';
-use Test::Most;
+use Test2::Bundle::Extended;
 use Scalar::Util 'looks_like_number';
 use Test::Class::Moose::Load qw(t/basiclib);
 use Test::Class::Moose::Runner;

--- a/t/include_classes.t
+++ b/t/include_classes.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-use Test::Most;
 use lib 'lib';
+use Test2::Bundle::Extended;
 use Test::Class::Moose::Load qw(t/basiclib);
 use Test::Class::Moose::Runner;
 
@@ -20,12 +20,16 @@ my %methods_for = (
     ],
 );
 my @test_classes = sort $runner->test_classes;
-eq_or_diff \@test_classes, [ sort keys %methods_for ],
-  'test_classes() should return a sorted list of test classes';
+is( \@test_classes,
+    [ sort keys %methods_for ],
+    'test_classes() should return a sorted list of test classes'
+);
 
 foreach my $class (@test_classes) {
-    eq_or_diff [ sort $class->new->test_methods ], $methods_for{$class},
-      "$class should have the correct test methods";
+    is( [ sort $class->new->test_methods ],
+        [ @{ $methods_for{$class} } ],
+        "$class should have the correct test methods"
+    );
 }
 
 done_testing;

--- a/t/include_exclude.t
+++ b/t/include_exclude.t
@@ -3,9 +3,7 @@
 use lib 'lib', 't/lib';
 
 use Test2::API qw( intercept );
-use Test2::Tools::Basic qw( done_testing ok );
-use Test2::Tools::Class qw( isa_ok );
-use Test2::Tools::Compare qw( array call end event is T );
+use Test2::Bundle::Extended;
 use Test::Events;
 
 use Test::Class::Moose::Load qw(t/basiclib);

--- a/t/load.t
+++ b/t/load.t
@@ -1,12 +1,10 @@
 #!/usr/bin/env perl
-use Test::Most 'bail';
-
 use lib 't/loadlib/helpers';
-
+use Test2::Bundle::Extended;
 require Test::Class::Moose::Load;
 
-throws_ok(
-    sub { Test::Class::Moose::Load->import('t/loadlib/tests') },
+like(
+    dies { Test::Class::Moose::Load->import('t/loadlib/tests') },
     qr{
           \QBareword "here" not allowed while "strict subs" in use at t\E.loadlib.helpers.Fail\Q.pm line 6\E
           .+

--- a/t/non_randomize_classes.t
+++ b/t/non_randomize_classes.t
@@ -1,14 +1,13 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test2::Bundle::Extended;
 use Test::Class::Moose::Load 't/randomlib';
 use Test::Class::Moose::Runner;
 
 my $tcmr = Test::Class::Moose::Runner->new( randomize_classes => 0 );
 
-is_deeply(
-    [ $tcmr->test_classes ],
+is( [ $tcmr->test_classes ],
     [qw( ClassA ClassB ClassC ClassD ClassE )],
     'got a sorted list of classes'
 );

--- a/t/parallel.t
+++ b/t/parallel.t
@@ -10,8 +10,7 @@ use Test::Requires {
 };
 
 use Test2::API qw( intercept );
-use Test2::Tools::Basic qw( done_testing skip_all );
-use Test2::Tools::Compare qw( array call end event filter_items F T is );
+use Test2::Bundle::Extended;
 use Test::Events;
 use Test::Reporting qw( test_report );
 

--- a/t/parameterized.t
+++ b/t/parameterized.t
@@ -3,8 +3,7 @@
 use lib 'lib', 't/lib';
 
 use Test2::API qw( intercept );
-use Test2::Tools::Basic qw( done_testing );
-use Test2::Tools::Compare qw( array call end event F is T );
+use Test2::Bundle::Extended;
 use Test::Events;
 use Test::Reporting qw( test_report );
 

--- a/t/plans.t
+++ b/t/plans.t
@@ -3,8 +3,7 @@
 use lib 'lib', 't/lib';
 
 use Test2::API qw( intercept );
-use Test2::Tools::Basic qw( done_testing );
-use Test2::Tools::Compare qw( array call end event is );
+use Test2::Bundle::Extended;
 use Test::Events;
 
 use Test::Class::Moose::Runner;

--- a/t/process_name.t
+++ b/t/process_name.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
-use Test::Most;
 use lib 'lib';
+use Test2::Bundle::Extended;
 use Test::Class::Moose::Load qw(t/processnamelib);
 use Test::Class::Moose::Runner;
 

--- a/t/reportpassed.t
+++ b/t/reportpassed.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::Most;
+use Test2::Bundle::Extended;
 
 use Test2::API qw( intercept );
 use Test::Class::Moose::Load qw(t/reportpassedlib);
@@ -10,7 +10,6 @@ use Test::Class::Moose::Runner;
 my $runner = Test::Class::Moose::Runner->new( show_timing => 0 );
 intercept { $runner->runtests };
 my $report = $runner->test_report;
-explain $report->time->duration;
 
 # note: because of a possible bug in Test::Builder::subtest returning a fail
 # status, even if the test is TODO, we rely on that feature to make these
@@ -85,8 +84,7 @@ for my $class ( $report->all_test_classes ) {
     }
 }
 
-is_deeply(
-    [ sort keys %got ],
+is( [ sort keys %got ],
     [ sort keys %expect ],
     'ran all the classes we expected',
 );
@@ -96,7 +94,7 @@ for my $class ( sort keys %expect ) {
         $expect{$class}{passed},
         "got expected pass/fail status for $class class"
     );
-    is_deeply(
+    is(
         [ sort keys %{ $got{$class}{instances} } ],
         [ sort keys %{ $expect{$class}{instances} } ],
         "ran all the $class instances we expected",
@@ -107,7 +105,7 @@ for my $class ( sort keys %expect ) {
             $expect{$class}{instances}{$instance}{passed},
             "got expected pass/fail status for $instance instance"
         );
-        is_deeply(
+        is(
             [ sort keys %{ $got{$class}{instances}{$instance}{methods} } ],
             [ sort keys %{ $expect{$class}{instances}{$instance}{methods} } ],
             "ran all the $instance methods we expected",

--- a/t/skip.t
+++ b/t/skip.t
@@ -3,8 +3,7 @@
 use lib 'lib', 't/lib';
 
 use Test2::API qw( intercept );
-use Test2::Tools::Basic qw( done_testing fail ok pass );
-use Test2::Tools::Compare qw( array call end event F is match T );
+use Test2::Bundle::Extended;
 use Test::Events;
 use Test::Reporting qw( test_report );
 

--- a/t/tags.t
+++ b/t/tags.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
-use Test::Most;
 use lib 'lib';
 
+use Test2::Bundle::Extended;
 use Test::Class::Moose ();    # prevents us from inheriting from it
 sub registry () {'Test::Class::Moose::AttributeRegistry'}
 
@@ -112,9 +112,10 @@ sub _run_tests {
     my @test_classes = sort $runner->test_classes;
 
     foreach my $class (@test_classes) {
-        eq_or_diff [ $runner->_executor->_test_methods_for( $class->new ) ],
-          $methods_for->{$class},
-          "$class should have the correct test methods";
+        is( [ $runner->_executor->_test_methods_for( $class->new ) ],
+            $methods_for->{$class},
+            "$class should have the correct test methods"
+        );
     }
 }
 

--- a/t/test_class_is_not_loaded.t
+++ b/t/test_class_is_not_loaded.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+
+use Test2::Bundle::Extended;
+
+use Test::Class::Moose::Runner;
+
+like(
+    dies {
+        Test::Class::Moose::Runner->new(
+            test_classes => ['Test::Class::Not::Loaded'],
+          )->runtests
+    },
+    qr/\QFound the following class that is not a subclass of Test::Class::Moose: Test::Class::Not::Loaded (did you load this class?)/,
+    'got expected error when trying to run a class which is not loaded'
+);
+
+{
+    package Foo;
+    sub foo {}
+}
+
+like(
+    dies {
+        Test::Class::Moose::Runner->new(
+            test_classes => ['Test::Class::Not::Loaded', 'Foo'],
+          )->runtests
+    },
+    qr/\QFound the following classes that are not subclasses of Test::Class::Moose: Test::Class::Not::Loaded Foo (did you load these classes?)/,
+    'got expected error when trying to run a class which is not loaded and one which is not a TCM subclass'
+);
+
+done_testing();

--- a/t/test_control_methods.t
+++ b/t/test_control_methods.t
@@ -3,8 +3,7 @@
 use lib 'lib', 't/lib';
 
 use Test2::API qw( intercept );
-use Test2::Tools::Basic qw( done_testing pass );
-use Test2::Tools::Compare qw( array call end event F match T );
+use Test2::Bundle::Extended;
 use Test2::Tools::Subtest qw( subtest_streamed );
 use Test::Events;
 

--- a/t/test_control_methods_skip.t
+++ b/t/test_control_methods_skip.t
@@ -3,8 +3,7 @@
 use lib 'lib', 't/lib';
 
 use Test2::API qw( intercept );
-use Test2::Tools::Basic qw( diag done_testing );
-use Test2::Tools::Compare qw( array call end event F );
+use Test2::Bundle::Extended;
 use Test2::Tools::Subtest qw( subtest_streamed );
 use Test::Events;
 use Test::Reporting qw( test_report );


### PR DESCRIPTION
This addresses #57 