### PR TITLE
Clean up some time related code

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Perl distribution Test-Class-Moose
 
 {{$NEXT}}
 
+  [ENHANCEMENTS]
+
+  * All report objects now have start_time and end_time methods.
+
 0.84     2017-05-15
 
   [ENHANCEMENTS]

--- a/lib/Test/Class/Moose/Report/Time.pm
+++ b/lib/Test/Class/Moose/Report/Time.pm
@@ -12,7 +12,7 @@ use List::Util qw( max );
 use namespace::autoclean;
 
 {
-    my @fields = qw( real user system _children_user _children_system );
+    my @fields = qw( real user system );
     for my $i ( 0 .. $#fields ) {
         has $fields[$i] => (
             is       => 'ro',

--- a/lib/Test/Class/Moose/Report/Time.pm
+++ b/lib/Test/Class/Moose/Report/Time.pm
@@ -24,14 +24,6 @@ use namespace::autoclean;
     }
 }
 
-has '_iters' => (
-    is       => 'ro',
-    isa      => 'Num',
-    lazy     => 1,
-    default  => sub { $_[0]->_timediff->[5] },
-    init_arg => undef,
-);
-
 has '_timediff' => (
     is       => 'ro',
     isa      => 'Benchmark',

--- a/lib/Test/Class/Moose/Role/HasTimeReport.pm
+++ b/lib/Test/Class/Moose/Role/HasTimeReport.pm
@@ -37,6 +37,21 @@ has 'time' => (
     builder => '_build_time',
 );
 
+# If Time::HiRes is available these will be non-integers
+has 'start_time' => (
+    is      => 'ro',
+    isa     => 'Num',
+    lazy    => 0,
+    default => sub { $_[0]->_start_benchmark->[0] },
+);
+
+has 'end_time' => (
+    is      => 'ro',
+    isa     => 'Num',
+    lazy    => 0,
+    default => sub { $_[0]->_end_benchmark->[0] },
+);
+
 sub _build_time {
     my $self = shift;
 
@@ -73,3 +88,11 @@ None.
 Returns a L<Test::Class::Moose::Report::Time> object. This object
 represents the duration of this class or method. The duration may be "0" if
 it's an abstract class with no tests run.
+
+=head2 C<start_time>
+
+Returns the start time for the report as an epoch value.
+
+=head2 C<end_time>
+
+Returns the end time for the report as an epoch value.

--- a/lib/Test/Class/Moose/Role/HasTimeReport.pm
+++ b/lib/Test/Class/Moose/Role/HasTimeReport.pm
@@ -15,21 +15,19 @@ use Benchmark qw(timediff timestr :hireswallclock);
 use Test::Class::Moose::Report::Time;
 
 has '_start_benchmark' => (
-    is            => 'ro',
-    isa           => 'Benchmark',
-    lazy          => 1,
-    default       => sub { Benchmark->new },
-    predicate     => '_has_start_benchmark',
-    documentation => 'Trusted method for Test::Class::Moose',
+    is        => 'ro',
+    isa       => 'Benchmark',
+    lazy      => 1,
+    default   => sub { Benchmark->new },
+    predicate => '_has_start_benchmark',
 );
 
 has '_end_benchmark' => (
-    is            => 'ro',
-    isa           => 'Benchmark',
-    lazy          => 1,
-    default       => sub { Benchmark->new },
-    predicate     => '_has_end_benchmark',
-    documentation => 'Trusted method for Test::Class::Moose',
+    is        => 'ro',
+    isa       => 'Benchmark',
+    lazy      => 1,
+    default   => sub { Benchmark->new },
+    predicate => '_has_end_benchmark',
 );
 
 has 'time' => (

--- a/t/lib/Test/Reporting.pm
+++ b/t/lib/Test/Reporting.pm
@@ -307,6 +307,14 @@ sub _test_control_methods {
         subtest_streamed(
             'timing report',
             sub {
+                is( $report,
+                    object {
+                        call start_time => $pos;
+                        call end_time   => $pos;
+                    },
+                    'report has start and end time'
+                );
+
                 can_ok( $report, 'time' );
                 my $time = $report->time;
                 isa_ok(

--- a/t/lib/Test/Reporting.pm
+++ b/t/lib/Test/Reporting.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use Test2::Tools::Basic qw( ok );
 use Test2::Tools::Class qw( can_ok isa_ok );
-use Test2::Tools::Compare qw( end field hash is T validator );
+use Test2::Tools::Compare qw( call end field hash is object T validator );
 use Test2::Tools::Subtest qw( subtest_streamed );
 
 use Scalar::Util 'looks_like_number';
@@ -13,6 +13,9 @@ use Scalar::Util 'looks_like_number';
 use Exporter qw( import );
 
 our @EXPORT_OK = 'test_report';
+
+my $PosOrZero
+  = validator( 'number >= 0' => sub { looks_like_number($_) && $_ >= 0 } );
 
 sub test_report {
     my $report = shift;
@@ -161,19 +164,13 @@ sub _method_timing_structure {
     };
 }
 
-{
-    my $pos_or_zero
-      = validator( 'number >= 0' => sub { looks_like_number($_) && $_ >= 0 }
-      );
-
-    sub _time_field {
-        return field time => hash {
-            field real   => $pos_or_zero;
-            field system => $pos_or_zero;
-            field user   => $pos_or_zero;
-            end();
-        };
-    }
+sub _time_field {
+    return field time => hash {
+        field real   => $PosOrZero;
+        field system => $PosOrZero;
+        field user   => $PosOrZero;
+        end();
+    };
 }
 
 sub _test_class_report {
@@ -300,29 +297,34 @@ sub _test_control_methods {
     }
 }
 
-sub _test_report_time {
-    my $report = shift;
+{
+    my $pos
+      = validator( 'number > 0', sub { looks_like_number($_) && $_ > 0 } );
 
-    subtest_streamed(
-        'timing report',
-        sub {
-            can_ok( $report, 'time' );
-            my $time = $report->time;
-            isa_ok(
-                $time,
-                'Test::Class::Moose::Report::Time',
-            );
+    sub _test_report_time {
+        my $report = shift;
 
-            for my $method (qw( real user system )) {
-                ok( looks_like_number( $time->$method ),
-                    qq{\$time->$method returns a number}
+        subtest_streamed(
+            'timing report',
+            sub {
+                can_ok( $report, 'time' );
+                my $time = $report->time;
+                isa_ok(
+                    $time,
+                    'Test::Class::Moose::Report::Time',
                 );
-                ok( $time->$method >= 0,
-                    'number is greater than or equal to zero'
+
+                is( $time,
+                    object {
+                        call real   => $PosOrZero;
+                        call system => $PosOrZero;
+                        call user   => $PosOrZero;
+                    },
+                    'time object has expected values'
                 );
             }
-        }
-    );
+        );
+    }
 }
 
 1;


### PR DESCRIPTION
Most importantly, this adds some methods needed by https://github.com/Ovid/test-class-moose-history so that code does not have to poke into the TCM internals in an unseemly way.