### PR TITLE
add bare => 1 to Test::Class::Moose::Role

### DIFF
--- a/t/bare.t
+++ b/t/bare.t
@@ -17,4 +17,17 @@ is( [ warnings { eval $package } ],
     'no warnings from using Test::Class::Moose with List::SomeUtils'
 );
 
+my $package2 = <<'EOF';
+package TestFor::Bare;
+
+use Test::Class::Moose::Role bare => 1;
+use Test::More;
+use List::SomeUtils qw( any );
+EOF
+
+is( [ warnings { eval $package2 } ],
+    array { end(); },
+    'no warnings from using Test::Class::Moose::Role with List::SomeUtils'
+);
+
 done_testing();


### PR DESCRIPTION
PR to allow 'use Test::Class::Moose::Role bare => 1'.  This allows roles to use tests from other test suites like Test2.